### PR TITLE
refactor(New): refactor how parent/child relationships are established

### DIFF
--- a/command.go
+++ b/command.go
@@ -24,9 +24,9 @@ var (
 	}
 )
 
-func New(spec Spec) *Command {
-	if spec.Parent != nil && !spec.Parent.createdByNewCommand {
-		panic("illegal parent was specified - was the parent created by 'command.NewCommand(...)'?")
+func New(parent *Command, spec Spec) *Command {
+	if parent != nil && !parent.createdByNewCommand {
+		panic("illegal parent was specified - was the parent created by 'command.New(...)'?")
 	}
 	cmd := &Command{
 		Name:                spec.Name,
@@ -34,7 +34,7 @@ func New(spec Spec) *Command {
 		LongDescription:     spec.LongDescription,
 		Config:              spec.Config,
 		Run:                 spec.Run,
-		Parent:              spec.Parent,
+		Parent:              parent,
 		createdByNewCommand: true,
 	}
 	if cmd.Parent != nil {
@@ -47,7 +47,6 @@ type Spec struct {
 	Name             string
 	ShortDescription string
 	LongDescription  string
-	Parent           *Command
 	Config           any
 	Run              func(ctx context.Context, config any, usagePrinter UsagePrinter) error
 }

--- a/command_test.go
+++ b/command_test.go
@@ -65,32 +65,29 @@ func Test_initializeFlagSet(t *testing.T) {
 func Test_printCommandUsage(t *testing.T) {
 	t.Parallel()
 
-	rootCmd := New(Spec{
+	rootCmd := New(nil, Spec{
 		Name:             "root",
 		ShortDescription: "Root command",
 		LongDescription:  "This command is the\nroot command.",
 		Config:           &RootConfig{},
 	})
-	sub1Cmd := New(Spec{
+	sub1Cmd := New(rootCmd, Spec{
 		Name:             "sub1",
 		ShortDescription: "Sub command 1",
 		LongDescription:  "This command is the\nfirst sub command.",
 		Config:           &Sub1Config{},
-		Parent:           rootCmd,
 	})
-	sub2Cmd := New(Spec{
+	sub2Cmd := New(rootCmd, Spec{
 		Name:             "sub2",
 		ShortDescription: "Sub command 2",
 		LongDescription:  "This command is the\nsecond sub command.",
 		Config:           &Sub2Config{},
-		Parent:           rootCmd,
 	})
-	sub3Cmd := New(Spec{
+	sub3Cmd := New(sub2Cmd, Spec{
 		Name:             "sub3",
 		ShortDescription: "Sub command 3",
 		LongDescription:  "This command is the\nthird sub command.",
 		Config:           &Sub3Config{},
-		Parent:           sub2Cmd,
 	})
 
 	type testCase struct {

--- a/util_test.go
+++ b/util_test.go
@@ -59,32 +59,29 @@ func Test_inferCommandFlagsAndPositionals(t *testing.T) {
 		expectedPositionals []string
 	}
 
-	rootCmd := New(Spec{
+	rootCmd := New(nil, Spec{
 		Name:             "root",
 		ShortDescription: "Root command",
 		LongDescription:  "This command is the\nroot command.",
 		Config:           &RootConfig{},
 	})
-	sub1Cmd := New(Spec{
+	sub1Cmd := New(rootCmd, Spec{
 		Name:             "sub1",
 		ShortDescription: "Sub command 1",
 		LongDescription:  "This command is the\nfirst sub command.",
 		Config:           &Sub1Config{},
-		Parent:           rootCmd,
 	})
-	sub2Cmd := New(Spec{
+	sub2Cmd := New(sub1Cmd, Spec{
 		Name:             "sub2",
 		ShortDescription: "Sub command 2",
 		LongDescription:  "This command is the\nsecond sub command.",
 		Config:           &Sub2Config{},
-		Parent:           sub1Cmd,
 	})
-	New(Spec{
+	New(sub2Cmd, Spec{
 		Name:             "sub3",
 		ShortDescription: "Sub command 3",
 		LongDescription:  "This command is the\nthird sub command.",
 		Config:           &Sub3Config{},
-		Parent:           sub2Cmd,
 	})
 
 	testCases := map[string]testCase{


### PR DESCRIPTION
This change updates the `New` method to receive parent, instead of specifying it in the command specification.

This enables writing just specs without referencing the commands, and then in the `main` package you can initialize the command chain by calling the `New` function for each command in sequence.