### PR TITLE
feat(command): support non-executable commands

### DIFF
--- a/execute.go
+++ b/execute.go
@@ -15,33 +15,6 @@ const (
 	ExitCodeMisconfiguration ExitCode = 2
 )
 
-// Executor is the interface to be implemented by custom commands.
-type Executor interface {
-	PreRun(ctx context.Context) error
-	Run(ctx context.Context) error
-}
-
-type InlineExecutor struct {
-	PreRunFunc func(context.Context) error
-	RunFunc    func(context.Context) error
-}
-
-func (i InlineExecutor) PreRun(ctx context.Context) error {
-	if i.PreRunFunc != nil {
-		return i.PreRunFunc(ctx)
-	} else {
-		return nil
-	}
-}
-
-func (i InlineExecutor) Run(ctx context.Context) error {
-	if i.PreRunFunc != nil {
-		return i.RunFunc(ctx)
-	} else {
-		return nil
-	}
-}
-
 // Execute the correct command in the given command hierarchy (starting at "root"), configured from the given CLI args
 // and environment variables. The command will be executed with the given context after all pre-RunFunc hooks have been
 // successfully executed in the command hierarchy.
@@ -75,17 +48,27 @@ func Execute(ctx context.Context, w io.Writer, root *Command, args []string, env
 
 	// Invoke all "PreRun" hooks on the whole chain of commands (starting at the root)
 	for _, c := range cmd.getChain() {
-		if err := c.executor.PreRun(ctx); err != nil {
-			_, _ = fmt.Fprintln(w, err)
-			return ExitCodeError
+		for _, hook := range c.preRunHooks {
+			if err := hook.PreRun(ctx); err != nil {
+				_, _ = fmt.Fprintln(w, err)
+				return ExitCodeError
+			}
 		}
 	}
 
-	// Run the command
-	if err := cmd.executor.Run(ctx); err != nil {
-		_, _ = fmt.Fprintln(w, err)
-		return ExitCodeError
+	// Run the command or print help screen if it's not a command
+	if cmd.action != nil {
+		if err := cmd.action.Run(ctx); err != nil {
+			_, _ = fmt.Fprintln(w, err)
+			return ExitCodeError
+		}
+	} else {
+		// Command is not a runner - print help
+		if err := cmd.PrintHelp(w, getTerminalWidth()); err != nil {
+			_, _ = fmt.Fprintf(w, "%s\n", err)
+			return ExitCodeError
+		}
 	}
-
 	return ExitCodeSuccess
+
 }

--- a/flag_set.go
+++ b/flag_set.go
@@ -72,14 +72,16 @@ type flagSet struct {
 	positionalsTargets []*[]string
 }
 
-func newFlagSet(parent *flagSet, valueOfConfig reflect.Value) (*flagSet, error) {
+func newFlagSet(parent *flagSet, objects ...reflect.Value) (*flagSet, error) {
 	fs := &flagSet{parent: parent}
-	if valueOfConfig.Kind() == reflect.Ptr && valueOfConfig.Type().Elem().Kind() == reflect.Struct {
-		if valueOfConfig.IsNil() {
-			valueOfConfig.Set(reflect.New(valueOfConfig.Type().Elem()))
-		}
-		if err := fs.readFlagsFromStruct(valueOfConfig.Elem(), false); err != nil {
-			return nil, err
+	for _, c := range objects {
+		if c.Kind() == reflect.Ptr && c.Type().Elem().Kind() == reflect.Struct {
+			if c.IsNil() {
+				c.Set(reflect.New(c.Type().Elem()))
+			}
+			if err := fs.readFlagsFromStruct(c.Elem(), false); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return fs, nil


### PR DESCRIPTION
This change provides support for fully-intermediate commands, that have no execution logic of their own - and only function as groups of other actions - though they can still have pre-run hooks, and also potential configurations (that may or may not be inherited).