### PR TITLE
fix(signal): remove call to os.Exit to ensure app cleanups are run

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -37,8 +37,6 @@ func SetupSignalHandler() context.Context {
 	go func() {
 		<-c
 		cancel()
-		<-c
-		os.Exit(1) // second signal. Exit directly.
 	}()
 
 	return ctx


### PR DESCRIPTION
This change removes the call to `os.Exit` on a 2nd OS signal, to ensure that the application's cleanups - most often represented as `defer` calls - are properly called (since calls to `os.Exit` prevent `defer` functions execution.)