### PR TITLE
fix(flags): apply CLI and environment vars values for post-run hooks

### DIFF
--- a/command.go
+++ b/command.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -161,6 +162,12 @@ func (c *Command) setParent(parent *Command) error {
 	}
 	for _, hook := range c.preRunHooks {
 		configObjects = append(configObjects, reflect.ValueOf(hook))
+	}
+	for _, hook := range c.postRunHooks {
+		hv := reflect.ValueOf(hook)
+		if !slices.ContainsFunc(configObjects, func(v reflect.Value) bool { return v.Interface() == hv.Interface() }) {
+			configObjects = append(configObjects, hv)
+		}
 	}
 	if fs, err := newFlagSet(parentFlags, configObjects...); err != nil {
 		return fmt.Errorf("failed creating flag-set for command '%s': %w", c.name, err)

--- a/command_test.go
+++ b/command_test.go
@@ -53,7 +53,16 @@ func TestNew(t *testing.T) {
 						Action
 						MyFlag string `flag:"true"`
 					}{},
-					nil,
+					[]any{
+						&struct {
+							TrackingPreRunHook
+							PreRunFlag string `flag:"true"`
+						}{},
+						&struct {
+							TrackingPostRunHook
+							PostRunFlag string `flag:"true"`
+						}{},
+					},
 				)
 			},
 			expectedFlagSet: &flagSet{
@@ -61,6 +70,20 @@ func TestNew(t *testing.T) {
 					{
 						flagInfo: flagInfo{
 							Name:     "my-flag",
+							HasValue: true,
+						},
+						Targets: []reflect.Value{},
+					},
+					{
+						flagInfo: flagInfo{
+							Name:     "pre-run-flag",
+							HasValue: true,
+						},
+						Targets: []reflect.Value{},
+					},
+					{
+						flagInfo: flagInfo{
+							Name:     "post-run-flag",
 							HasValue: true,
 						},
 						Targets: []reflect.Value{},


### PR DESCRIPTION
This change fixes an omission bug that causes flags of post-run hooks not to be parsed and applied.